### PR TITLE
Improvements to the rules and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,68 @@
 # unifi-wazuh
-Decoders and rules for Wazuh
+Custom Wazuh decoders and rules for UniFi Network devices. Parses CEF (Common Event Format) syslog events from UniFi OS and UniFi Network applications.
 
-using UniFi OS v4.3.9 and UniFi Network 9.5.21
+Tested using UniFi OS 4.4.9 + UniFi Network 10.0.162 + Wazuh 4.14.
 
-oct25:
-* divided syslog traffic events based on firewall action
-* ordered key values by section
-* preliminary fields for Threat Detected and Blocked events
+## Events Covered
 
-dec12:
-* small fix to base in severity field
+| Rule ID | Event | Level |
+|---------|-------|-------|
+| 100102 | Base UniFi event (silent parent) | 0 |
+| 100103 | UniFi Console event | 3 |
+| 100104 | Traffic Internal Allow (LAN→LAN) | 3 |
+| 100105 | Traffic External Allow (LAN→WAN) | 3 |
+| 100106 | Traffic Internal Block (LAN→LAN) | 7 |
+| 100107 | Traffic External Block (LAN→WAN) | 7 |
+| 100110 | Configuration Change | 8 |
+| 100111 | IPS Threat Detected | 10 |
+| 100112 | WiFi Client Connected | 3 |
+| 100113 | WiFi Client Disconnected | 3 |
+
+Rules include compliance mappings for PCI DSS, NIST 800-53, and HIPAA.
+
+## Installation
+
+Copy the decoder and rules files to your Wazuh manager:
+
+```bash
+cp unifi_decoders.xml /var/ossec/etc/decoders/
+cp unifi_rules.xml /var/ossec/etc/rules/
+```
+
+Restart the Wazuh manager:
+
+```bash
+systemctl restart wazuh-manager
+```
+
+## Testing
+
+Use `wazuh-logtest` to validate decoder and rule matching:
+
+```bash
+/var/ossec/bin/wazuh-logtest
+```
+
+Use `wazuh-analysisd` to validate the decoders and rules:
+```bash
+/var/ossec/bin/wazuh-analysisd -t
+```
+
+Paste a sample UniFi syslog line to verify the correct decoder and rules match.
+
+## Changelog
+
+2025-12-22:
+* Added compliance mappings to rules (PCI DSS, NIST 800-53, HIPAA)
+* Renumbered rule IDs from 100002-100007 to 100102-100113
+* Adjusted rule levels: base rule now silent (level 0), allow rules level 3, block rules level 7
+* Added new rules: config change detection (100110), IPS threat detection (100111), WiFi client connect/disconnect (100112/100113)
+* Updated tested versions to UniFi OS 4.4.9, UniFi Network 10.0.162, Wazuh 4.14
+
+2025-12-12:
+* Small fix to base in severity field
+
+2025-10-25:
+* Divided syslog traffic events based on firewall action
+* Ordered key values by section
+* Preliminary fields for Threat Detected and Blocked events

--- a/unifi_rules.xml
+++ b/unifi_rules.xml
@@ -1,36 +1,69 @@
 <group name="unifi">
-  <rule id="100002" level="6">
+  <!-- base rule (silent parent) -->
+  <rule id="100102" level="0">
     <decoded_as>unifi</decoded_as>
     <match>Ubiquiti</match>
     <description>UniFi $(type) event</description>
   </rule>
-  <rule id="100003" level="6">
-    <if_sid>100002</if_sid>
+
+  <!-- console events -->
+  <rule id="100103" level="3">
+    <if_sid>100102</if_sid>
     <match>UniFi OS</match>
     <description>UniFi Console $(type) event</description>
   </rule>
-  <rule id="100004" level="6">
+
+  <!-- traffic allow -->
+  <rule id="100104" level="3">
     <decoded_as>unifi-lan2lan</decoded_as>
     <match>LAN_LAN</match>
     <field name="type">A</field>
     <description>Traffic Internal Allow</description>
   </rule>
-  <rule id="100005" level="6">
+  <rule id="100105" level="3">
     <decoded_as>unifi-lan2wan</decoded_as>
     <match>LAN_WAN</match>
     <field name="type">A</field>
     <description>Traffic External Allow</description>
   </rule>
-  <rule id="100006" level="6">
+
+  <!-- traffic block -->
+  <rule id="100106" level="7">
     <decoded_as>unifi-lan2lan</decoded_as>
     <match>LAN_LAN</match>
     <field name="type">D</field>
     <description>Traffic Internal Block</description>
   </rule>
-  <rule id="100007" level="6">
+  <rule id="100107" level="7">
     <decoded_as>unifi-lan2wan</decoded_as>
     <match>LAN_WAN</match>
     <field name="type">D</field>
     <description>Traffic External Block</description>
+  </rule>
+
+  <!-- config changes -->
+  <rule id="100110" level="8">
+    <if_sid>100102</if_sid>
+    <field name="uni_changeagent">\w+</field>
+    <description>UniFi Config Change by $(uni_changeagent) in $(uni_changedsection)</description>
+  </rule>
+
+  <!-- threat detection -->
+  <rule id="100111" level="10">
+    <if_sid>100102</if_sid>
+    <field name="uni_risk">\w+</field>
+    <description>UniFi IPS Threat Detected: $(uni_signature)</description>
+  </rule>
+
+  <!-- wifi events -->
+  <rule id="100112" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">400</field>
+    <description>WiFi Client Connected: $(uni_clientdev) to $(uni_ssid)</description>
+  </rule>
+  <rule id="100113" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">401</field>
+    <description>WiFi Client Disconnected: $(uni_clientdev) from $(uni_ssid)</description>
   </rule>
 </group>

--- a/unifi_rules.xml
+++ b/unifi_rules.xml
@@ -19,12 +19,14 @@
     <match>LAN_LAN</match>
     <field name="type">A</field>
     <description>Traffic Internal Allow</description>
+    <group>pci_dss_10.2.1,nist_800_53_AU-3,hipaa_164.312(b)</group>
   </rule>
   <rule id="100105" level="3">
     <decoded_as>unifi-lan2wan</decoded_as>
     <match>LAN_WAN</match>
     <field name="type">A</field>
     <description>Traffic External Allow</description>
+    <group>pci_dss_10.2.1,nist_800_53_AU-3,hipaa_164.312(b)</group>
   </rule>
 
   <!-- traffic block -->
@@ -33,12 +35,14 @@
     <match>LAN_LAN</match>
     <field name="type">D</field>
     <description>Traffic Internal Block</description>
+    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_AU-3,hipaa_164.312(e)(1)</group>
   </rule>
   <rule id="100107" level="7">
     <decoded_as>unifi-lan2wan</decoded_as>
     <match>LAN_WAN</match>
     <field name="type">D</field>
     <description>Traffic External Block</description>
+    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_AU-3,hipaa_164.312(e)(1)</group>
   </rule>
 
   <!-- config changes -->
@@ -46,6 +50,7 @@
     <if_sid>100102</if_sid>
     <field name="uni_changeagent">\w+</field>
     <description>UniFi Config Change by $(uni_changeagent) in $(uni_changedsection)</description>
+    <group>pci_dss_10.5.5,pci_dss_11.5,nist_800_53_CM-3,nist_800_53_CM-6,nist_800_53_AU-12,hipaa_164.312(b)</group>
   </rule>
 
   <!-- threat detection -->
@@ -53,6 +58,7 @@
     <if_sid>100102</if_sid>
     <field name="uni_risk">\w+</field>
     <description>UniFi IPS Threat Detected: $(uni_signature)</description>
+    <group>pci_dss_11.4,nist_800_53_SI-4,nist_800_53_SI-3,hipaa_164.308(a)(5)(ii)(B)</group>
   </rule>
 
   <!-- wifi events -->
@@ -60,10 +66,12 @@
     <if_sid>100102</if_sid>
     <field name="event_id">400</field>
     <description>WiFi Client Connected: $(uni_clientdev) to $(uni_ssid)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b)</group>
   </rule>
   <rule id="100113" level="3">
     <if_sid>100102</if_sid>
     <field name="event_id">401</field>
     <description>WiFi Client Disconnected: $(uni_clientdev) from $(uni_ssid)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b)</group>
   </rule>
 </group>


### PR DESCRIPTION
I liked your start; thanks for that. I've done some improvements to the rules and the README.md:

* Added compliance mappings to rules (PCI DSS, NIST 800-53, HIPAA)
* Renumbered rule IDs from 100002-100007 to 100102-100113
* Adjusted rule levels: base rule now silent (level 0), allow rules level 3, block rules level 7
* Added new rules: config change detection (100110), IPS threat detection (100111), WiFi client connect/disconnect (100112/100113)
* Updated tested versions to UniFi OS 4.4.9, UniFi Network 10.0.162, Wazuh 4.14