### PR TITLE
Added support for UniFi OS 5.0.16 / Network 10.2.105

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # unifi-wazuh
-Custom Wazuh decoders and rules for UniFi Network devices. Parses CEF (Common Event Format) syslog events from UniFi OS and UniFi Network applications.
+Custom Wazuh decoders and rules for UniFi Network devices. Parses CEF (Common Event Format) syslog events and hostapd device syslog from UniFi OS and UniFi Network applications.
 
-Tested using UniFi OS 4.4.9 + UniFi Network 10.0.162 + Wazuh 4.14.
+Tested using UniFi OS 5.0.16 + UniFi Network 10.2.105 + Wazuh 4.14.
 
 ## Events Covered
+
+### CEF Event Rules
 
 | Rule ID | Event | Level |
 |---------|-------|-------|
@@ -17,8 +19,44 @@ Tested using UniFi OS 4.4.9 + UniFi Network 10.0.162 + Wazuh 4.14.
 | 100111 | IPS Threat Detected | 10 |
 | 100112 | WiFi Client Connected | 3 |
 | 100113 | WiFi Client Disconnected | 3 |
+| 100114 | Admin Accessed UniFi | 5 |
+| 100115 | Device Adopted | 5 |
+| 100116 | Device Offline | 8 |
+| 100117 | WiFi Client Roaming | 3 |
+| 100118 | Wired Client Connected | 3 |
+| 100119 | Wired Client Disconnected | 3 |
+| 100120 | Honeypot Triggered | 12 |
+| 100121 | Blocked by Firewall (CEF) | 10 |
+| 100122 | WAN Failover | 8 |
+| 100123 | High Latency Detected | 5 |
+| 100124 | Packet Loss Detected | 7 |
+| 100125 | Insufficient PoE Output | 7 |
+| 100126 | AP Underpowered | 5 |
+| 100127 | PoE Availability Exceeded | 7 |
+| 100128 | IPS Threat from Internal Host | 13 |
+| 100199 | Unmatched CEF Event (catch-all) | 3 |
 
-Rules include compliance mappings for PCI DSS, NIST 800-53, and HIPAA.
+### Hostapd Rules
+
+| Rule ID | Event | Level |
+|---------|-------|-------|
+| 100200 | Hostapd grouping (silent parent) | 0 |
+| 100201 | STA Associated | 3 |
+| 100202 | STA Disassociated | 3 |
+| 100203 | RADIUS Auth Success | 5 |
+| 100204 | RADIUS Auth Failed | 8 |
+
+### Correlation / Frequency Rules
+
+| Rule ID | Triggers On | Threshold | Level |
+|---------|------------|-----------|-------|
+| 100150 | LAN block (100106) | 10 in 2 min, same src | 10 |
+| 100151 | WAN block (100107) | 10 in 2 min, same src | 10 |
+| 100152 | IPS threat (100111) | 5 in 5 min | 13 |
+| 100153 | WiFi disconnect (100113) | 8 in 1 min, same client | 8 |
+| 100210 | RADIUS fail (100204) | 5 in 2 min, same MAC | 10 |
+
+Rules include compliance mappings for PCI DSS, NIST 800-53, HIPAA, and MITRE ATT&CK.
 
 ## Installation
 
@@ -27,6 +65,13 @@ Copy the decoder and rules files to your Wazuh manager:
 ```bash
 cp unifi_decoders.xml /var/ossec/etc/decoders/
 cp unifi_rules.xml /var/ossec/etc/rules/
+```
+
+Set the decoder and rules permissions appropriately:
+
+```bash
+chown wazuh:wazuh /var/ossec/etc/decoders/unifi_decoders.xml && chmod 660 /var/ossec/etc/decoders/unifi_decoders.xml
+chown wazuh:wazuh /var/ossec/etc/rules/unifi_rules.xml && chmod 660 /var/ossec/etc/rules/unifi_rules.xml
 ```
 
 Restart the Wazuh manager:
@@ -51,6 +96,20 @@ Use `wazuh-analysisd` to validate the decoders and rules:
 Paste a sample UniFi syslog line to verify the correct decoder and rules match.
 
 ## Changelog
+
+2026-04-19:
+* Added support for UniFi OS 5.0.16 / Network 10.2.105
+* IPv6 support in CEF `src=`, `dst=`, `UNIFIclientIp=` decoders
+* Broadened lookahead patterns to prevent value bleed across KV fields
+* Added `UNIFIutcTime` decoder for new timestamp field
+* Added 10 new KV field decoders (clientMac, networkName, networkSubnet, networkVlan, deviceName, deviceModel, deviceIp, deviceMac, duration, ipsSessionId)
+* Added hostapd device syslog decoders and rules (STA association, RADIUS auth)
+* Added MITRE ATT&CK mappings to all rules
+* Added 14 new CEF event rules: admin access (544), device adopted/offline (200/201), WiFi roaming (304), wired client connect/disconnect (302/303), honeypot (401+Security), firewall block CEF (402), WAN failover/latency/loss (500-502), PoE events (600-602)
+* Added enrichment rule for IPS threats from internal hosts (100128)
+* Added catch-all rule for unmatched CEF events (100199)
+* Added 5 correlation/frequency rules for scan detection, attack detection, deauth, and RADIUS brute force
+* Fixed event_id 401 collision between WiFi disconnect and honeypot using category disambiguation
 
 2025-12-22:
 * Added compliance mappings to rules (PCI DSS, NIST 800-53, HIPAA)

--- a/unifi_decoders.xml
+++ b/unifi_decoders.xml
@@ -44,13 +44,13 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIsubCategory=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIsubCategory=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_subcat</order>
 </decoder>
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIhost=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIhost=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_host</order>
 </decoder>
 
@@ -62,7 +62,7 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">src=(\d+\.\d+\.\d+\.\d+)</regex>
+  <regex type="pcre2">src=((?:(?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]{2,39}))</regex>
   <order>srcip</order>
 </decoder>
 
@@ -75,44 +75,44 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
 <!-- config changes -->
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIsettingsSection=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIsettingsSection=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_changedsection</order>
 </decoder>
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIsettingsEntry=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIsettingsEntry=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_changedentry</order>
 </decoder>
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIadmin=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIadmin=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_changeagent</order>
 </decoder>
 
 <!-- wifi -->
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIclientAlias=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIclientAlias=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_clientdev</order>
 </decoder>
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIclientIp=(\d+\.\d+\.\d+\.\d+)</regex>
+  <regex type="pcre2">UNIFIclientIp=((?:(?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]{2,39}))</regex>
   <order>uni_clientip</order>
 </decoder>
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIwifiName=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIwifiName=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_ssid</order>
 </decoder>
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIWiFiRssi=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIWiFiRssi=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_rssi</order>
 </decoder>
 
@@ -131,7 +131,7 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">dst=(\d+\.\d+\.\d+\.\d+)</regex>
+  <regex type="pcre2">dst=((?:(?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]{2,39}))</regex>
   <order>dstip</order>
 </decoder>
 
@@ -149,7 +149,7 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
 
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIipsSignature=(.+?)(?=\s(?:UNIFI\w+=|src=|msg=))</regex>
+  <regex type="pcre2">UNIFIipsSignature=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_signature</order>
 </decoder>
 
@@ -157,4 +157,88 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
   <parent>unifi</parent>
   <regex type="pcre2">UNIFIipsSignatureId=(\d+)</regex>
   <order>uni_sigid</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIutcTime=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_utctime</order>
+</decoder>
+
+<!-- client/device/network KV fields -->
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIclientMac=([0-9a-fA-F:]{17})</regex>
+  <order>uni_clientmac</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFInetworkName=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_netname</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFInetworkSubnet=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_netsubnet</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFInetworkVlan=(\d+)</regex>
+  <order>uni_netvlan</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIdeviceName=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_devname</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIdeviceModel=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_devmodel</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIdeviceIp=((?:(?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]{2,39}))</regex>
+  <order>uni_devip</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIdeviceMac=([0-9a-fA-F:]{17})</regex>
+  <order>uni_devmac</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIduration=(\d+)</regex>
+  <order>uni_duration</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIipsSessionId=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_ipssessionid</order>
+</decoder>
+
+<!-- hostapd device syslog -->
+<decoder name="unifi-hostapd">
+  <program_name>hostapd</program_name>
+</decoder>
+
+<decoder name="unifi-hostapd">
+  <parent>unifi-hostapd</parent>
+  <regex type="pcre2">(\S+): STA ([0-9a-fA-F:]{17}) [\w ]+ (associated|disassociated)</regex>
+  <order>uni_iface, srcmac, uni_action</order>
+</decoder>
+
+<decoder name="unifi-hostapd">
+  <parent>unifi-hostapd</parent>
+  <regex type="pcre2">(\S+): STA ([0-9a-fA-F:]{17}) [\w ]+ RADIUS (authentication|accounting) (succeeded|failed)</regex>
+  <order>uni_iface, srcmac, uni_action, uni_radius_result</order>
 </decoder>

--- a/unifi_rules.xml
+++ b/unifi_rules.xml
@@ -11,6 +11,7 @@
     <if_sid>100102</if_sid>
     <match>UniFi OS</match>
     <description>UniFi Console $(type) event</description>
+    <group>mitre_t1078</group>
   </rule>
 
   <!-- traffic allow -->
@@ -19,14 +20,14 @@
     <match>LAN_LAN</match>
     <field name="type">A</field>
     <description>Traffic Internal Allow</description>
-    <group>pci_dss_10.2.1,nist_800_53_AU-3,hipaa_164.312(b)</group>
+    <group>pci_dss_10.2.1,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1021</group>
   </rule>
   <rule id="100105" level="3">
     <decoded_as>unifi-lan2wan</decoded_as>
     <match>LAN_WAN</match>
     <field name="type">A</field>
     <description>Traffic External Allow</description>
-    <group>pci_dss_10.2.1,nist_800_53_AU-3,hipaa_164.312(b)</group>
+    <group>pci_dss_10.2.1,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1048</group>
   </rule>
 
   <!-- traffic block -->
@@ -35,14 +36,14 @@
     <match>LAN_LAN</match>
     <field name="type">D</field>
     <description>Traffic Internal Block</description>
-    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_AU-3,hipaa_164.312(e)(1)</group>
+    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_AU-3,hipaa_164.312(e)(1),mitre_t1046</group>
   </rule>
   <rule id="100107" level="7">
     <decoded_as>unifi-lan2wan</decoded_as>
     <match>LAN_WAN</match>
     <field name="type">D</field>
     <description>Traffic External Block</description>
-    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_AU-3,hipaa_164.312(e)(1)</group>
+    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_AU-3,hipaa_164.312(e)(1),mitre_t1071</group>
   </rule>
 
   <!-- config changes -->
@@ -50,7 +51,7 @@
     <if_sid>100102</if_sid>
     <field name="uni_changeagent">\w+</field>
     <description>UniFi Config Change by $(uni_changeagent) in $(uni_changedsection)</description>
-    <group>pci_dss_10.5.5,pci_dss_11.5,nist_800_53_CM-3,nist_800_53_CM-6,nist_800_53_AU-12,hipaa_164.312(b)</group>
+    <group>pci_dss_10.5.5,pci_dss_11.5,nist_800_53_CM-3,nist_800_53_CM-6,nist_800_53_AU-12,hipaa_164.312(b),mitre_t1562</group>
   </rule>
 
   <!-- threat detection -->
@@ -58,7 +59,7 @@
     <if_sid>100102</if_sid>
     <field name="uni_risk">\w+</field>
     <description>UniFi IPS Threat Detected: $(uni_signature)</description>
-    <group>pci_dss_11.4,nist_800_53_SI-4,nist_800_53_SI-3,hipaa_164.308(a)(5)(ii)(B)</group>
+    <group>pci_dss_11.4,nist_800_53_SI-4,nist_800_53_SI-3,hipaa_164.308(a)(5)(ii)(B),mitre_t1190</group>
   </rule>
 
   <!-- wifi events -->
@@ -66,12 +67,193 @@
     <if_sid>100102</if_sid>
     <field name="event_id">400</field>
     <description>WiFi Client Connected: $(uni_clientdev) to $(uni_ssid)</description>
-    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b)</group>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
   </rule>
   <rule id="100113" level="3">
     <if_sid>100102</if_sid>
     <field name="event_id">401</field>
+    <field name="uni_cat">Monitoring</field>
     <description>WiFi Client Disconnected: $(uni_clientdev) from $(uni_ssid)</description>
-    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b)</group>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+
+  <!-- admin access -->
+  <rule id="100114" level="5">
+    <if_sid>100102</if_sid>
+    <field name="event_id">544</field>
+    <description>Admin Accessed UniFi via $(uni_accessway)</description>
+    <group>pci_dss_10.2.2,nist_800_53_AC-6,nist_800_53_AU-3,hipaa_164.312(a)(1),mitre_t1078</group>
+  </rule>
+
+  <!-- device events -->
+  <rule id="100115" level="5">
+    <if_sid>100102</if_sid>
+    <field name="event_id">200</field>
+    <description>UniFi Device Adopted: $(uni_devname)</description>
+    <group>pci_dss_11.2,nist_800_53_CM-8,hipaa_164.310(d)(1),mitre_t1200</group>
+  </rule>
+  <rule id="100116" level="8">
+    <if_sid>100102</if_sid>
+    <field name="event_id">201</field>
+    <description>UniFi Device Offline: $(uni_devname)</description>
+    <group>pci_dss_10.6,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1489</group>
+  </rule>
+
+  <!-- wifi roaming -->
+  <rule id="100117" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">304</field>
+    <description>WiFi Client Roaming: $(uni_clientdev)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+
+  <!-- wired client events -->
+  <rule id="100118" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">302</field>
+    <description>Wired Client Connected: $(uni_clientdev)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+  <rule id="100119" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">303</field>
+    <description>Wired Client Disconnected: $(uni_clientdev)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+
+  <!-- security events -->
+  <rule id="100120" level="12">
+    <if_sid>100102</if_sid>
+    <field name="event_id">401</field>
+    <field name="uni_cat">Security</field>
+    <description>Honeypot Triggered from $(srcip)</description>
+    <group>pci_dss_11.4,nist_800_53_SI-4,nist_800_53_SI-3,hipaa_164.308(a)(5)(ii)(B),mitre_t1046</group>
+  </rule>
+  <rule id="100121" level="10">
+    <if_sid>100102</if_sid>
+    <field name="event_id">402</field>
+    <description>Blocked by Firewall: $(uni_signature)</description>
+    <group>pci_dss_1.3.2,pci_dss_11.4,nist_800_53_SC-7,nist_800_53_SI-4,hipaa_164.312(e)(1),mitre_t1071</group>
+  </rule>
+
+  <!-- WAN events -->
+  <rule id="100122" level="8">
+    <if_sid>100102</if_sid>
+    <field name="event_id">500</field>
+    <description>WAN Failover Detected</description>
+    <group>pci_dss_10.6,nist_800_53_CP-10,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1499</group>
+  </rule>
+  <rule id="100123" level="5">
+    <if_sid>100102</if_sid>
+    <field name="event_id">501</field>
+    <description>High Latency Detected on WAN</description>
+    <group>pci_dss_10.6,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1499</group>
+  </rule>
+  <rule id="100124" level="7">
+    <if_sid>100102</if_sid>
+    <field name="event_id">502</field>
+    <description>Packet Loss Detected on WAN</description>
+    <group>pci_dss_10.6,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1499</group>
+  </rule>
+
+  <!-- PoE events -->
+  <rule id="100125" level="7">
+    <if_sid>100102</if_sid>
+    <field name="event_id">600</field>
+    <description>Insufficient PoE Output on $(uni_devname)</description>
+    <group>pci_dss_10.6,nist_800_53_PE-1,hipaa_164.310(a)(2)(ii),mitre_t1200</group>
+  </rule>
+  <rule id="100126" level="5">
+    <if_sid>100102</if_sid>
+    <field name="event_id">601</field>
+    <description>AP Underpowered: $(uni_devname)</description>
+    <group>pci_dss_10.6,nist_800_53_PE-1,hipaa_164.310(a)(2)(ii),mitre_t1200</group>
+  </rule>
+  <rule id="100127" level="7">
+    <if_sid>100102</if_sid>
+    <field name="event_id">602</field>
+    <description>PoE Availability Exceeded on $(uni_devname)</description>
+    <group>pci_dss_10.6,nist_800_53_PE-1,hipaa_164.310(a)(2)(ii),mitre_t1200</group>
+  </rule>
+
+  <!-- enrichment: IPS threat from internal source -->
+  <rule id="100128" level="13">
+    <if_sid>100111</if_sid>
+    <srcip>10.0.0.0/8</srcip>
+    <srcip>172.16.0.0/12</srcip>
+    <srcip>192.168.0.0/16</srcip>
+    <description>IPS Threat from Internal Host $(srcip): $(uni_signature)</description>
+    <group>pci_dss_11.4,nist_800_53_SI-4,nist_800_53_IR-4,hipaa_164.308(a)(6)(ii),mitre_t1190</group>
+  </rule>
+
+  <!-- correlation / frequency rules -->
+  <rule id="100150" level="10" frequency="10" timeframe="120">
+    <if_matched_sid>100106</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple Internal Blocks from $(srcip) (possible lateral scan)</description>
+    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_SI-4,hipaa_164.312(e)(1),mitre_t1046</group>
+  </rule>
+  <rule id="100151" level="10" frequency="10" timeframe="120">
+    <if_matched_sid>100107</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple External Blocks from $(srcip) (possible exfiltration attempts)</description>
+    <group>pci_dss_1.3.2,pci_dss_10.2.4,nist_800_53_SC-7,nist_800_53_SI-4,hipaa_164.312(e)(1),mitre_t1048</group>
+  </rule>
+  <rule id="100152" level="13" frequency="5" timeframe="300">
+    <if_matched_sid>100111</if_matched_sid>
+    <description>Multiple IPS Threats Detected (possible active attack)</description>
+    <group>pci_dss_11.4,nist_800_53_SI-4,nist_800_53_IR-4,hipaa_164.308(a)(6)(ii),mitre_t1190</group>
+  </rule>
+  <rule id="100153" level="8" frequency="8" timeframe="60">
+    <if_matched_sid>100113</if_matched_sid>
+    <same_field>uni_clientdev</same_field>
+    <description>Frequent WiFi Disconnects for $(uni_clientdev) (possible deauth attack)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1498</group>
+  </rule>
+
+  <!-- catch-all for unmatched CEF events -->
+  <rule id="100199" level="3">
+    <if_sid>100102</if_sid>
+    <description>UniFi CEF Event: $(type) (event_id $(event_id))</description>
+  </rule>
+
+  <!-- hostapd rules -->
+  <rule id="100200" level="0">
+    <decoded_as>unifi-hostapd</decoded_as>
+    <description>UniFi hostapd event</description>
+  </rule>
+  <rule id="100201" level="3">
+    <if_sid>100200</if_sid>
+    <field name="uni_action">associated</field>
+    <description>STA $(srcmac) Associated on $(uni_iface)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+  <rule id="100202" level="3">
+    <if_sid>100200</if_sid>
+    <field name="uni_action">disassociated</field>
+    <description>STA $(srcmac) Disassociated from $(uni_iface)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+  <rule id="100203" level="5">
+    <if_sid>100200</if_sid>
+    <field name="uni_action">authentication</field>
+    <field name="uni_radius_result">succeeded</field>
+    <description>RADIUS Auth Success for $(srcmac) on $(uni_iface)</description>
+    <group>pci_dss_10.2.5,nist_800_53_IA-2,nist_800_53_AU-3,hipaa_164.312(d),mitre_t1078</group>
+  </rule>
+  <rule id="100204" level="8">
+    <if_sid>100200</if_sid>
+    <field name="uni_action">authentication</field>
+    <field name="uni_radius_result">failed</field>
+    <description>RADIUS Auth Failed for $(srcmac) on $(uni_iface)</description>
+    <group>pci_dss_10.2.4,nist_800_53_IA-2,nist_800_53_AU-3,hipaa_164.312(d),mitre_t1110</group>
+  </rule>
+
+  <!-- hostapd correlation -->
+  <rule id="100210" level="10" frequency="5" timeframe="120">
+    <if_matched_sid>100204</if_matched_sid>
+    <same_field>srcmac</same_field>
+    <description>Multiple RADIUS Auth Failures for $(srcmac) (possible brute force)</description>
+    <group>pci_dss_10.2.4,pci_dss_11.4,nist_800_53_IA-2,nist_800_53_SI-4,hipaa_164.312(d),mitre_t1110</group>
   </rule>
 </group>


### PR DESCRIPTION
* IPv6 support in CEF `src=`, `dst=`, `UNIFIclientIp=` decoders
* Broadened lookahead patterns to prevent value bleed across KV fields
* Added `UNIFIutcTime` decoder for new timestamp field
* Added 10 new KV field decoders (clientMac, networkName, networkSubnet, networkVlan, deviceName, deviceModel, deviceIp, deviceMac, duration, ipsSessionId)
* Added hostapd device syslog decoders and rules (STA association, RADIUS auth)
* Added MITRE ATT&CK mappings to all rules
* Added 14 new CEF event rules: admin access (544), device adopted/offline (200/201), WiFi roaming (304), wired client connect/disconnect (302/303), honeypot (401+Security), firewall block CEF (402), WAN failover/latency/loss (500-502), PoE events (600-602)
* Added enrichment rule for IPS threats from internal hosts (100128)
* Added catch-all rule for unmatched CEF events (100199)
* Added 5 correlation/frequency rules for scan detection, attack detection, deauth, and RADIUS brute force
* Fixed event_id 401 collision between WiFi disconnect and honeypot using category disambiguation