### PR TITLE
fix: UNIFIcategory decoder truncation and rules 100112/100113 category mismatch

### DIFF
--- a/unifi_decoders.xml
+++ b/unifi_decoders.xml
@@ -38,7 +38,7 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
 <!-- kv start -->
 <decoder name="unifi">
   <parent>unifi</parent>
-  <regex type="pcre2">UNIFIcategory=(\w+)</regex>
+  <regex type="pcre2">UNIFIcategory=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
   <order>uni_cat</order>
 </decoder>
 

--- a/unifi_rules.xml
+++ b/unifi_rules.xml
@@ -66,13 +66,14 @@
   <rule id="100112" level="3">
     <if_sid>100102</if_sid>
     <field name="event_id">400</field>
+    <field name="uni_cat">Client Devices</field>
     <description>WiFi Client Connected: $(uni_clientdev) to $(uni_ssid)</description>
     <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
   </rule>
   <rule id="100113" level="3">
     <if_sid>100102</if_sid>
     <field name="event_id">401</field>
-    <field name="uni_cat">Monitoring</field>
+    <field name="uni_cat">Client Devices</field>
     <description>WiFi Client Disconnected: $(uni_clientdev) from $(uni_ssid)</description>
     <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
   </rule>


### PR DESCRIPTION
## Problem

`UNIFIcategory` decoder uses `(\w+)` which stops at whitespace, causing 
multi-word categories like `Client Devices` to be truncated to `Client`.

Rule 100113 matched on `uni_cat=Monitoring` which is incorrect — 
WiFi Client Disconnected events carry `UNIFIcategory=Client Devices`.
Rule 100112 had no category check at all.

## Fix

- `unifi_decoders.xml`: Changed `UNIFIcategory` regex from `(\w+)` to the 
  same lookahead pattern already used by `UNIFIsubCategory` and other 
  multi-word fields.
- `unifi_rules.xml`: Added `uni_cat=Client Devices` to rule 100112, 
  corrected rule 100113 from `Monitoring` to `Client Devices`.

## Tested with

UniFi OS 5.0.16, UniFi Network 10.3.58, Wazuh 4.14.5