### PR TITLE
Add IPS client attribution decoder + newer-firmware event IDs

### DIFF
--- a/unifi_decoders.xml
+++ b/unifi_decoders.xml
@@ -226,6 +226,19 @@ Jul 30 05:35:34 udr7 CEF:0|Ubiquiti|UniFi Network|9.3.45|400|WiFi Client Connect
   <order>uni_ipssessionid</order>
 </decoder>
 
+<!-- IPS threat: client that triggered the alert -->
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIsrcClientAlias=(.+?)(?=\s(?:UNIFI\w+=|src=|dst=|spt=|dpt=|proto=|msg=))</regex>
+  <order>uni_srcclientalias</order>
+</decoder>
+
+<decoder name="unifi">
+  <parent>unifi</parent>
+  <regex type="pcre2">UNIFIsrcClientMac=([0-9a-fA-F:]{17})</regex>
+  <order>uni_srcclientmac</order>
+</decoder>
+
 <!-- hostapd device syslog -->
 <decoder name="unifi-hostapd">
   <program_name>hostapd</program_name>

--- a/unifi_rules.xml
+++ b/unifi_rules.xml
@@ -99,6 +99,13 @@
     <description>UniFi Device Offline: $(uni_devname)</description>
     <group>pci_dss_10.6,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1489</group>
   </rule>
+  <!-- event_id 112 confirmed live on UniFi Network 10.4.57 (UCG-Fiber) -->
+  <rule id="100108" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">112</field>
+    <description>High Latency Detected on $(uni_devname)</description>
+    <group>pci_dss_10.6,nist_800_53_SI-4,hipaa_164.312(b),mitre_t1499</group>
+  </rule>
 
   <!-- wifi roaming -->
   <rule id="100117" level="3">
@@ -118,6 +125,17 @@
   <rule id="100119" level="3">
     <if_sid>100102</if_sid>
     <field name="event_id">303</field>
+    <description>Wired Client Disconnected: $(uni_clientdev)</description>
+    <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
+  </rule>
+  <!-- event_id 404 confirmed live on UniFi Network 10.4.x (UCG-Fiber) as an
+       alternate value for the same "Wired Client Disconnected" event that
+       100119 covers via event_id 303 on older firmware; kept as a
+       separate rule rather than replacing 303, since firmware versions
+       appear to disagree on the ID and this repo doesn't pin a version. -->
+  <rule id="100109" level="3">
+    <if_sid>100102</if_sid>
+    <field name="event_id">404</field>
     <description>Wired Client Disconnected: $(uni_clientdev)</description>
     <group>pci_dss_10.2.5,nist_800_53_AC-17,nist_800_53_AU-3,hipaa_164.312(b),mitre_t1078</group>
   </rule>


### PR DESCRIPTION
## Summary
Verified live against a UniFi Network 10.4.57 controller (UCG-Fiber), each change confirmed via `wazuh-logtest` against real captured log lines (not hand-typed samples):

- **Decoder addition**: `uni_srcclientalias`/`uni_srcclientmac` — IPS threat alerts include `UNIFIsrcClientAlias`/`UNIFIsrcClientMac` in the raw CEF log, but nothing extracted them, so alerts never showed which client triggered a threat.
- **Rule 100109** (new, not a replacement): `event_id 404` as an alternate "Wired Client Disconnected" ID alongside the existing `100119` (`event_id 303`). Newer firmware appears to emit `404` for the same event `100119` covers via `303`. Added as a separate rule rather than swapping the ID in `100119`, since this repo doesn't pin a firmware version and older installs may still rely on `303` — didn't want to break existing users on older firmware.
- **Rule 100108** (new): `event_id 112`, "High Latency Detected" — not previously covered.

## Test plan
- [x] Both XML files parse cleanly (`xml.dom.minidom` for rules; decoders file has multiple top-level elements by design, matching this repo's existing style)
- [x] `wazuh-analysisd -t` passes
- [x] Each new/changed rule and decoder confirmed via `wazuh-logtest` against real captured log lines from a live UCG-Fiber controller
- [x] Manager restarted and alerts confirmed flowing for the new rule IDs against real (not synthetic) traffic